### PR TITLE
Fix a bug of not passing variable arguments to the forward method (#20)

### DIFF
--- a/core/simulator/Simulator.m
+++ b/core/simulator/Simulator.m
@@ -17,7 +17,7 @@ classdef Simulator < handle
         end
         
         function step(obj, dt, varargin)
-            obj.system.forward();
+            obj.system.forward(varargin{:});
             if obj.saveHistory
                 obj.system.saveHistory();
             end
@@ -26,10 +26,10 @@ classdef Simulator < handle
             t0 = obj.time;
             y0 = obj.system.state;
             
-            k1 = obj.system.stateDeriv();
-            k2 = obj.system.stateDeriv(y0 + dt/2*k1, t0 + dt/2);
-            k3 = obj.system.stateDeriv(y0 + dt/2*k2, t0 + dt/2);
-            k4 = obj.system.stateDeriv(y0 + dt*k3, t0 + dt);
+            k1 = obj.system.stateDeriv([], [], varargin{:});
+            k2 = obj.system.stateDeriv(y0 + dt/2*k1, t0 + dt/2, varargin{:});
+            k3 = obj.system.stateDeriv(y0 + dt/2*k2, t0 + dt/2, varargin{:});
+            k4 = obj.system.stateDeriv(y0 + dt*k3, t0 + dt, varargin{:});
             
             % update time and states
             t = t0 + dt;

--- a/core/systems/BaseSystem.m
+++ b/core/systems/BaseSystem.m
@@ -46,7 +46,7 @@ classdef(Abstract) BaseSystem < handle
             obj.time = timeFeed;
         end
         
-        function out = stateDeriv(obj, stateFeed, timeFeed)
+        function out = stateDeriv(obj, stateFeed, timeFeed, varargin)
             % Assume that stateFeed and timeFeed are always given
             % together
             if nargin < 3
@@ -57,7 +57,7 @@ classdef(Abstract) BaseSystem < handle
                 applyState(obj, stateFeed);
                 applyTime(obj, timeFeed);
             end
-            forward(obj);
+            forward(obj, varargin{:});
             
             out = nan(obj.stateNum, 1);
             for k = 1:numel(obj.stateVarList)

--- a/core/systems/DynSystem.m
+++ b/core/systems/DynSystem.m
@@ -65,11 +65,6 @@ classdef DynSystem < BaseSystem
             obj.stateVar.value = stateFeed;
         end
         
-        % override
-        function out = stateDeriv(obj)
-            out = obj.stateVar.flatDeriv;
-        end
-        
         % implement
         function out = forward(obj, varargin)
             obj.inValues = varargin;
@@ -130,14 +125,14 @@ classdef DynSystem < BaseSystem
             u_step = 1;
             y = linearSystem.forward(u_step);
             
-            x_dot = linearSystem.stateDeriv;
+            x_dot = linearSystem.stateVar.deriv;
             
             fprintf('A = [0, 1; -1, -1], B = [0; 1] \n')
             fprintf('linearSystem = DynSystem([0; 1], @(x, u) A*x + B*u) \n')
             fprintf('linearSystem.forward(u_step) where u_step = 1 \n')
             fprintf('linearSystem.output: \n')
             disp(y)
-            fprintf('linearSystem.stateDeriv: \n')
+            fprintf('linearSystem.stateVar.deriv: \n')
             disp(x_dot);
         end
     end

--- a/core/systems/DynSystem.m
+++ b/core/systems/DynSystem.m
@@ -65,6 +65,23 @@ classdef DynSystem < BaseSystem
             obj.stateVar.value = stateFeed;
         end
         
+        % override
+        function out = stateDeriv(obj, stateFeed, timeFeed, varargin)
+            % Assume that stateFeed and timeFeed are always given
+            % together
+            if nargin < 3
+                stateFeed = [];
+                timeFeed = [];
+            end
+            if ~isempty(stateFeed) && ~isempty(timeFeed)
+                applyState(obj, stateFeed);
+                applyTime(obj, timeFeed);
+            end
+            forward(obj, varargin{:});
+            
+            out = stateVar.flatDeriv;
+        end
+        
         % implement
         function out = forward(obj, varargin)
             obj.inValues = varargin;

--- a/core/systems/SequentialSystem.m
+++ b/core/systems/SequentialSystem.m
@@ -78,7 +78,7 @@ classdef(Abstract) SequentialSystem < BaseSystem
             if nargin < 3 || isempty(saveHistory)
                 saveHistory = true;
             end
-            obj.forward();
+            obj.forward(varargin{:});
             if saveHistory
                 obj.saveHistory();
             end


### PR DESCRIPTION
Methods of `Simulator`, `BaseSystem`, `DynSystem`, `SequntialSystem` have been changed to allow passing a variable number of arguments when performing a simulation. Now `DynSystem` alone can be used in the simulator.