### PR TITLE
Fix a bug in the logging feature (#37)

### DIFF
--- a/core/simulator/Simulator.m
+++ b/core/simulator/Simulator.m
@@ -10,17 +10,19 @@ classdef Simulator < handle
             obj.stateNum = system.stateNum;
         end
         
-        function step(obj, dt, saveHistory, varargin)
-            if nargin < 3 || isempty(saveHistory)
-                saveHistory = true;
-            end
-            
+        function startLogging(obj, interval)
+            obj.system.startLogging(interval);
+        end
+        
+        function finishLogging(obj)
+            obj.system.finishLogging();
+            obj.system.saveHistory();
+        end
+        
+        function step(obj, dt, varargin)
             if ~obj.initialized
                 obj.system.forward(varargin{:});
                 obj.initialized = true;
-                if saveHistory
-                    obj.system.saveHistory();
-                end
             end
             
             % remember initial state values
@@ -32,22 +34,18 @@ classdef Simulator < handle
             k1 = odeFun([], []);
             k2 = odeFun(y0 + dt/2*k1, t0 + dt/2);
             k3 = odeFun(y0 + dt/2*k2, t0 + dt/2);
-            k4 = odeFun(y0 + dt*k3, t0 + dt);
+            k4 = odeFun(y0 + (dt - 2*eps)*k3, t0 + dt - 2*eps);
             
             % update time and states
             t = t0 + dt;
             y = y0 + dt*(k1 + 2*k2 + 2*k3 + k4)/6;
             obj.system.applyTime(t);
             obj.system.applyState(y);
-            
-            if saveHistory
-                obj.system.saveHistory();
-            end
         end
         
         function propagate(obj, dt, time, saveHistory, varargin)
             if nargin < 4 || isempty(saveHistory)
-                saveHistory = true;
+                saveHistory = false;
             end
             
             if saveHistory
@@ -68,7 +66,7 @@ classdef Simulator < handle
                 k1 = odeFun(y, t);
                 k2 = odeFun(y + dt/2*k1, t + dt/2);
                 k3 = odeFun(y + dt/2*k2, t + dt/2);
-                k4 = odeFun(y + (dt - eps)*k3, t + dt - eps);
+                k4 = odeFun(y + (dt - 10*eps)*k3, t + dt - 10*eps);
                 
                 % update time and states
                 t = t + dt;
@@ -76,7 +74,6 @@ classdef Simulator < handle
             end
             obj.system.applyTime(t);
             obj.system.applyState(y);
-            obj.system.saveHistory();
             
             obj.system.finishLogging();
         end
@@ -84,7 +81,11 @@ classdef Simulator < handle
     
     methods(Static)
         function test()
+            clc
+            close all
+            
             fprintf('== Test for Simulator class == \n')
+            fprintf('Test for propagate method \n')
             fprintf('Simulating the system... \n')
             
             mySystem = MySystem(); % Refer to MySystem class
@@ -103,9 +104,18 @@ classdef Simulator < handle
             fprintf('Initial state of the system: \n')
             disp(initialState)
             fprintf('Elapsed time: %.2f [s] \n', elapsedTime);
-            fprintf('State of the system after 10[s]: \n')
+            fprintf('State of the system after 10[s]: \n\n')
             disp(mySystem.state)
             
+            mySystem.plot();
+            
+            fprintf('Test for step method \n')
+            mySystem.reset();
+            simulator.startLogging(0.1);
+            for i = 1:100
+                simulator.step(0.01);
+            end
+            simulator.finishLogging();
             mySystem.plot();
         end
     end

--- a/core/systems/BaseSystem.m
+++ b/core/systems/BaseSystem.m
@@ -5,7 +5,7 @@ classdef(Abstract) BaseSystem < handle
         stateVarNum
         stateNum
         stateIndex
-        logTimer = []
+        logTimer
         name
     end
     methods
@@ -58,7 +58,9 @@ classdef(Abstract) BaseSystem < handle
                 applyTime(obj, timeFeed);
             end
             forward(obj, varargin{:});
-            obj.logTimer.forward(obj.time);
+            if ~isempty(obj.logTimer)
+                obj.logTimer.forward(obj.time);
+            end
             
             out = nan(obj.stateNum, 1);
             for k = 1:numel(obj.stateVarList)
@@ -67,7 +69,7 @@ classdef(Abstract) BaseSystem < handle
                 out(index, 1) = stateVar.flatDeriv;
             end
             
-            if obj.logTimer.checkEvent()
+            if ~isempty(obj.logTimer) && obj.logTimer.checkEvent()
                 saveHistory(obj);
             end
         end
@@ -77,12 +79,13 @@ classdef(Abstract) BaseSystem < handle
                 obj.logTimer = Timer(interval);
             end
             obj.logTimer.eventTimeInterval = interval;
-            obj.logTimer.turnOn(true);
-            obj.logTimer.forward(obj.time);
+            obj.logTimer.turnOn(obj.time, true);
         end
         
         function finishLogging(obj)
-            obj.logTimer.turnOff();
+            if ~isempty(obj.logTimer)
+                obj.logTimer.turnOff();
+            end
         end
         
         % to be overriden

--- a/core/systems/MultipleSystem.m
+++ b/core/systems/MultipleSystem.m
@@ -9,6 +9,7 @@ classdef MultipleSystem < BaseSystem
         end
         
         function reset(obj)
+            obj.time = 0;
             for k = 1:numel(obj.systemList)
                 obj.systemList{k}.reset();
             end

--- a/core/utils/Timer.m
+++ b/core/utils/Timer.m
@@ -1,9 +1,9 @@
 classdef Timer < handle
     properties
-        isOperating = false
         eventTimeInterval
+        isOperating = false
         lastEventTime
-        isEvent = true
+        isEvent = false
     end
     methods
         function obj = Timer(eventTimeInterval)
@@ -15,29 +15,30 @@ classdef Timer < handle
             obj.lastEventTime = 0;
         end
         
-        function turnOn(obj, withInitialEvent)
-            if nargin < 2 || isempty(withInitialEvent)
+        function turnOn(obj, time, withInitialEvent)
+            if nargin < 3 || isempty(withInitialEvent)
                 withInitialEvent = false;
             end
             assert(~isnan(obj.eventTimeInterval), "Set the eventTimeInterval first before turning on the timer.")
             
             obj.isOperating = true;
-            if withInitialEvent
-                obj.lastEventTime = -inf;
-            end
+            obj.lastEventTime = time;
+            obj.isEvent = withInitialEvent;
         end
         
         function turnOff(obj)
             obj.isOperating = false;
+            obj.lastEventTime = [];
+            obj.isEvent = [];
         end
         
         function forward(obj, time)
-            if abs(time - obj.lastEventTime) <= 2*eps
+            if abs(time - obj.lastEventTime) <= 10*eps
                 return
             end
             if obj.isOperating
                 elapsedTime = time - obj.lastEventTime;
-                if elapsedTime >= obj.eventTimeInterval - 2*eps
+                if elapsedTime >= obj.eventTimeInterval - eps
                     obj.isEvent = true;
                     obj.lastEventTime = time;
                 else
@@ -58,7 +59,6 @@ classdef Timer < handle
             eventTimeInterval = 1;
             
             timer = Timer(eventTimeInterval);
-            timer.turnOn();
             dt = 0.4;
             
             fprintf('Initial time: 0.0[s] \n')
@@ -66,6 +66,7 @@ classdef Timer < handle
             fprintf('Sampling time interval: %.1f[s] \n', dt)
             
             time = 0;
+            timer.turnOn(time, false);
             for i = 1:5
                 timer.forward(time);
                 isEvent = timer.checkEvent();


### PR DESCRIPTION
* A bug in `reset` method of `MultipleSystem` class has been fixed.
* Mechanism of `Timer` class has been slightly changed.
* `startLogging` and `finishLogging` methods have been added to `Simulator` class.
* Logging features of `Simulator` class have been improved

To use the logging feature with `step` method, call `simulator.startLogging()` before iterating `step` method, and call `simulator.finishLogging()` after the iteration.