### PR TITLE
Add output variable to BaseSystem

### DIFF
--- a/core/systems/BaseSystem.m
+++ b/core/systems/BaseSystem.m
@@ -74,6 +74,11 @@ classdef(Abstract) BaseSystem < handle
             end
         end
         
+        % to be overridden
+        function out = output(obj)
+            % implement this method if needed
+        end
+        
         function startLogging(obj, interval)
             if isempty(obj.logTimer)
                 obj.logTimer = Timer(interval);

--- a/core/systems/MultiStateDynSystem.m
+++ b/core/systems/MultiStateDynSystem.m
@@ -52,6 +52,7 @@ classdef MultiStateDynSystem < BaseSystem
             obj.outputFun = outputFun;
         end
         
+        % override
         function out = output(obj)
             if isa(obj.outputFun, 'BaseFunction')
                 out = obj.outputFun.evaluate(obj.state);

--- a/core/systems/TimeVaryingDynSystem.m
+++ b/core/systems/TimeVaryingDynSystem.m
@@ -49,6 +49,7 @@ classdef TimeVaryingDynSystem < BaseSystem
             obj.outputFun = outputFun;
         end
         
+        % override
         function out = output(obj)
             if isa(obj.outputFun, 'BaseFunction')
                 out = obj.outputFun.evaluate(obj.state, obj.time);


### PR DESCRIPTION
* A pseudo `output` method has been added to `BaseSystem`, which is intended to be overridden.
* To use `output` variable of a system, `output` method of the system must have been already defined.