### PR TITLE
Enable defining a derivative function by overriding a method (#44)

### DIFF
--- a/core/systems/DynSystem.m
+++ b/core/systems/DynSystem.m
@@ -10,6 +10,9 @@ classdef DynSystem < TimeVaryingDynSystem
             if nargin < 3 || isempty(outputFun)
                 outputFun = @(x) x;
             end
+            if nargin < 2
+                derivFun = [];
+            end
             obj = obj@TimeVaryingDynSystem(initialState, derivFun, outputFun, name);
         end
         

--- a/core/systems/MultiStateDynSystem.m
+++ b/core/systems/MultiStateDynSystem.m
@@ -69,10 +69,16 @@ classdef MultiStateDynSystem < BaseSystem
             for k = 1:obj.stateVarNum
                 stateValueList{k} = obj.stateVarList{k}.value;
             end
-            derivList = obj.derivFun(stateValueList{:}, varargin{:});
+            
+            if isa(obj.derivFun, 'BaseFunction')
+                derivList = obj.derivFun.forward(stateValueList{:}, varargin{:});
+            else
+                derivList = obj.derivFun(stateValueList{:}, varargin{:});
+            end
             for k = 1:obj.stateVarNum
                 obj.stateVarList{k}.deriv = derivList{k};
             end
+            
             if nargout > 0
                 out = obj.output;
             end

--- a/core/systems/MultiStateDynSystem.m
+++ b/core/systems/MultiStateDynSystem.m
@@ -15,6 +15,9 @@ classdef MultiStateDynSystem < BaseSystem
             if nargin < 3 || isempty(outputFun)
                 outputFun = @(varargin) varargin{:};
             end
+            if nargin < 2
+                derivFun = [];
+            end
             
             subStateVarNum = numel(initialState);
             subStateVarList = cell(1, subStateVarNum);
@@ -25,6 +28,9 @@ classdef MultiStateDynSystem < BaseSystem
             obj.initialState = initialState;
             obj.history = MatStackedData();
             
+            if isempty(derivFun)
+                derivFun = @obj.derivative;
+            end
             attachDerivFun(obj, derivFun);
             attachOutputFun(obj, outputFun);
         end
@@ -81,6 +87,16 @@ classdef MultiStateDynSystem < BaseSystem
             
             if nargout > 0
                 out = obj.output;
+            end
+        end
+        
+        % to be overridden
+        function out = derivative(obj, varargin)
+            % implement this method if needed
+            fprintf("Attach a derivFun or implement the derivative method! \n")
+            out = cell(size(obj.initialState));
+            for k = 1:numel(out)
+                out{k} = zeros(size(obj.initialState{k}));
             end
         end
     end

--- a/core/systems/TimeVaryingDynSystem.m
+++ b/core/systems/TimeVaryingDynSystem.m
@@ -13,12 +13,18 @@ classdef TimeVaryingDynSystem < BaseSystem
             if nargin < 3 || isempty(outputFun)
                 outputFun = @(x, t) x;
             end
+            if nargin < 2
+                derivFun = [];
+            end
             initialState = initialState(:);
             stateVarList = {StateVariable(initialState)};
             obj = obj@BaseSystem(stateVarList, name);
             obj.initialState = initialState;
             obj.history = MatStackedData();
             
+            if isempty(derivFun)
+                derivFun = @obj.derivative;
+            end
             attachDerivFun(obj, derivFun);
             attachOutputFun(obj, outputFun);
         end
@@ -97,6 +103,13 @@ classdef TimeVaryingDynSystem < BaseSystem
             if nargout > 0
                 out = obj.output;
             end
+        end
+        
+        % to be overridden
+        function out = derivative(obj, varargin)
+            % implement this method if needed
+            fprintf("Attach a derivFun or implement the derivative method! \n")
+            out = zeros(size(obj.initialState));
         end
     end
     

--- a/examples/SecondOrderDynSystem.m
+++ b/examples/SecondOrderDynSystem.m
@@ -1,0 +1,24 @@
+classdef SecondOrderDynSystem < DynSystem
+    properties
+        zeta
+        omega
+        A
+        B
+    end
+    methods
+        function obj = SecondOrderDynSystem(initialState, zeta, omega)
+            obj = obj@DynSystem(initialState);
+            obj.zeta = zeta;
+            obj.omega = omega;
+            obj.A = [...
+                0, 1;
+                -omega^2, -2*zeta*omega];
+            obj.B = [0; omega^2];
+        end
+        
+        % override
+        function out = derivative(obj, x, u)
+            out = obj.A*x + obj.B*u;
+        end
+    end
+end

--- a/examples/dyn_system_example.m
+++ b/examples/dyn_system_example.m
@@ -1,0 +1,58 @@
+clear
+clc
+close all
+addpath(genpath('../core'))
+fprintf('== Test for SecondOrderDynSystem == \n')
+
+zeta = 0.5;
+omega = 1;
+
+dt = 0.01;
+finalTime = 10;
+u_step = 1;
+
+% Using a function handle
+fprintf("Using a function handle \n")
+tic
+A = [...
+    0, 1;
+    -omega^2, -2*zeta*omega];
+B = [0; omega^2];
+derivFun = @(x, u) A*x + B*u;
+system1 = DynSystem([0; 0], derivFun);
+Simulator(system1).propagate(dt, finalTime, true, u_step);
+elapsedTime = toc;
+
+fprintf("Elapsed time: %.2f [s] \n\n", elapsedTime);
+
+% Using a BaseFunction object
+fprintf("Using a BaseFunction object \n")
+tic
+system2 = DynSystem([0; 0], SecondOrderDyn(zeta, omega));
+Simulator(system2).propagate(dt, finalTime, true, u_step);
+elapsedTime = toc;
+
+fprintf("Elapsed time: %.2f [s] \n\n", elapsedTime);
+
+% Using class inheritance
+fprintf("Using class inheritance \n")
+tic
+system3 = SecondOrderDynSystem([0; 0], zeta, omega);
+Simulator(system3).propagate(dt, finalTime, true, u_step);
+elapsedTime = toc;
+
+fprintf("Elapsed time: %.2f [s] \n\n", elapsedTime);
+
+fig1 = figure();
+sgtitle('function handle')
+system1.plot(fig1);
+
+fig2 = figure();
+sgtitle('BaseFunction')
+system2.plot(fig2);
+
+fig3 = figure();
+sgtitle('class inheritance')
+system3.plot(fig3);
+
+rmpath(genpath('../core'))


### PR DESCRIPTION
* A skeleton `derivative` method has been added to `TimeVaryingDynSystem` and `MultiStateDynSystem`, respectively.
* If no argument is passed for `derivFun`, the constructor automatically assigns the `derivative` method for `derivFun`.
* To use a class inheriting `DynSystem`, `TimeVaryingDynSystem` or `MultiStateDynSystem`, `derivative` method should be defined in a proper way.