### PR TITLE
Add 'stateValueList' method to BaseSystem (#49)

### DIFF
--- a/core/systems/BaseSystem.m
+++ b/core/systems/BaseSystem.m
@@ -27,18 +27,23 @@ classdef(Abstract) BaseSystem < handle
         
         function out = state(obj)
             out = nan(obj.stateNum, 1);
-            for k = 1:numel(obj.stateVarList)
-                stateVar = obj.stateVarList{k};
+            for k = 1:obj.stateVarNum
                 index = obj.stateIndex{k};
-                out(index, 1) = stateVar.flatValue;
+                out(index, 1) = obj.stateVarList{k}.flatValue;
+            end
+        end
+        
+        function out = stateValueList(obj)
+            out = cell(1, obj.stateVarNum);
+            for k = 1:obj.stateVarNum
+                out{k} = obj.stateVarList{k}.value;
             end
         end
         
         function applyState(obj, stateFeed)
             for k = 1:numel(obj.stateVarList)
-                stateVar = obj.stateVarList{k};
                 index = obj.stateIndex{k};
-                stateVar.setFlatValue(stateFeed(index, 1));
+                obj.stateVarList{k}.setFlatValue(stateFeed(index, 1));
             end
         end
         

--- a/core/systems/MultiStateDynSystem.m
+++ b/core/systems/MultiStateDynSystem.m
@@ -61,9 +61,9 @@ classdef MultiStateDynSystem < BaseSystem
         % override
         function out = output(obj)
             if isa(obj.outputFun, 'BaseFunction')
-                out = obj.outputFun.evaluate(obj.state);
+                out = obj.outputFun.evaluate(obj.stateValueList{:});
             else
-                out = obj.outputFun(obj.state);
+                out = obj.outputFun(obj.stateValueList{:});
             end
         end
         
@@ -71,15 +71,10 @@ classdef MultiStateDynSystem < BaseSystem
         function out = forward(obj, varargin)
             obj.inValues = varargin;
             
-            stateValueList = cell(1, obj.stateVarNum);
-            for k = 1:obj.stateVarNum
-                stateValueList{k} = obj.stateVarList{k}.value;
-            end
-            
             if isa(obj.derivFun, 'BaseFunction')
-                derivList = obj.derivFun.forward(stateValueList{:}, varargin{:});
+                derivList = obj.derivFun.forward(obj.stateValueList{:}, varargin{:});
             else
-                derivList = obj.derivFun(stateValueList{:}, varargin{:});
+                derivList = obj.derivFun(obj.stateValueList{:}, varargin{:});
             end
             for k = 1:obj.stateVarNum
                 obj.stateVarList{k}.deriv = derivList{k};


### PR DESCRIPTION
* `stateValueList` method has been added to `BaseSystem`.
* When `stateValueList` method is called, the value of each state variable is returned as a cell array.
* Several methods has been modified to use `stateValueList` method.