### PR TITLE
Add a quaternion based controller for the quadrotor model (#53)

### DIFF
--- a/multicopter/AttQuatControl.m
+++ b/multicopter/AttQuatControl.m
@@ -1,0 +1,36 @@
+classdef AttQuatControl < BaseFunction
+    % Ref: J. Carino, H. Abaunza and P. Castillo, 2015,
+    % "Quadrotor Quaternion Control"
+    properties
+        J
+        K
+    end
+    methods
+        function obj = AttQuatControl(J, K)
+            obj.J = J;
+            obj.K = K;
+        end
+        
+        % implement
+        function tau = forward(obj, q, omega, q_d, omega_d)
+            [a, phi] = Orientations.quatToAxisAngle(q);
+            theta = a*phi;
+            x = [theta; omega];
+            
+            [a_d, phi_d] = Orientations.quatToAxisAngle(q_d);
+            theta_d = a_d*phi_d;
+            x_d = [theta_d; omega_d];
+            
+            u = -obj.K*(x - x_d);
+            tau = obj.J*u + cross(omega, obj.J*omega);
+        end
+    end
+    methods(Static)
+        function K = gain(Q, R)
+            A = [zeros(3, 3), eye(3);
+                zeros(3, 3), zeros(3, 3)];
+            B = [zeros(3, 3); eye(3)];
+            K = lqr(A, B, Q, R, []);
+        end
+    end
+end

--- a/multicopter/AttQuatStabilization.m
+++ b/multicopter/AttQuatStabilization.m
@@ -1,0 +1,49 @@
+classdef AttQuatStabilization < MultipleSystem
+    properties
+        quadrotor
+        attControl
+    end
+    methods
+        function obj = AttQuatStabilization()
+            obj = obj@MultipleSystem();
+            
+            % quadrotor model
+            m = 1.3;
+            J = diag([0.0119, 0.0119, 0.0219]);
+            
+            pos = [1; 2; 0];
+            vel = [0; 0; 0];
+            R_vi = Orientations.eulerAnglesToRotation(...
+                deg2rad([10; 10; 20]));
+            R_iv = R_vi.';
+            omega = [0; 0; 1];
+            initialState = {pos, vel, R_iv, omega};
+            
+            obj.quadrotor = QuadrotorDyn(initialState, m, J);
+            
+            % attitude controller
+            Q = diag([1, 1, 1, 0.1, 0.1, 0.1].^2);
+            R = 0.0001*eye(3);
+            K = AttQuatControl.gain(Q, R);
+            obj.attControl = AttQuatControl(J, K);
+            
+            obj.attachDynSystems({obj.quadrotor});
+        end
+        
+        % implement
+        function forward(obj)
+            q_d = [1; 0; 0; 0];
+            omega_d = [0; 0; 0];
+            
+            quadState = obj.quadrotor.stateValueList;
+            R_iv = quadState{3};
+            omega = quadState{4};
+            q = Orientations.rotationToQuat(R_iv.');
+            
+            f = obj.quadrotor.m*obj.quadrotor.g;
+            tau = obj.attControl.forward(q, omega, q_d, omega_d);
+            
+            obj.quadrotor.forward([f; tau]);
+        end
+    end
+end

--- a/multicopter/PosQuatControl.m
+++ b/multicopter/PosQuatControl.m
@@ -1,0 +1,53 @@
+classdef PosQuatControl < BaseFunction
+    % Ref: J. Carino, H. Abaunza and P. Castillo, 2015,
+    % "Quadrotor Quaternion Control"
+    properties
+        m
+        K
+        grav
+        n = [0; 0; -1];
+    end
+    methods
+        function obj = PosQuatControl(m, K, grav)
+            if nargin < 3
+                grav = 9.805*[0; 0; 1];
+            end
+            obj.m = m;
+            obj.K = K;
+            obj.grav = grav;
+        end
+        
+        % implement
+        function [f, q_d, omega_d] = forward(obj, p, v, p_d, v_d)
+            x = [p; v];
+            x_d = [p_d; v_d];
+            u = -obj.K*(x - x_d);
+            
+            u_pd = u - obj.grav;
+            f = obj.m*norm(u_pd);
+            
+            r_d = [...
+                obj.n.'*u_pd + norm(u_pd);
+                cross(obj.n, u_pd)];
+            q_d = r_d / norm(r_d);
+            
+            u_pd_dot = -obj.K*[v; u];
+            r_d_dot = [...
+                obj.n.'*u_pd_dot + u_pd.'*u_pd_dot/norm(u_pd);
+                cross(obj.n, u_pd_dot)];
+            q_d_dot = r_d_dot/norm(r_d) + r_d*(-r_d.'*r_d_dot/norm(r_d)^3);
+            
+            omega_d = 2*conj(quaternion(q_d.'))*quaternion(q_d_dot.');
+            omega_d = compact(omega_d);
+            omega_d = omega_d(2:4).';
+        end
+    end
+    methods(Static)
+        function K = gain(Q, R)
+            A = [zeros(3, 3), eye(3);
+                zeros(3, 3), zeros(3, 3)];
+            B = [zeros(3, 3); eye(3)];
+            K = lqr(A, B, Q, R, []);
+        end
+    end
+end

--- a/multicopter/PosQuatStabilization.m
+++ b/multicopter/PosQuatStabilization.m
@@ -1,0 +1,53 @@
+classdef PosQuatStabilization < MultipleSystem
+    properties
+        quadrotor
+        attControl
+        posControl
+    end
+    methods
+        function obj = PosQuatStabilization()
+            obj = obj@MultipleSystem();
+            
+            % quadrotor model
+            m = 1.3;
+            J = diag([0.0119, 0.0119, 0.0219]);
+            
+            pos = [1; 2; 0];
+            vel = [0; 0; 0];
+            R_vi = eye(3);
+            R_iv = R_vi.';
+            omega = [0; 0; 0];
+            initialState = {pos, vel, R_iv, omega};
+            
+            obj.quadrotor = QuadrotorDyn(initialState, m, J);
+            
+            % attitude controller
+            Q_att = diag([1, 1, 1, 0.1, 0.1, 0.1].^2);
+            R_att = 0.0001*eye(3);
+            K_att = AttQuatControl.gain(Q_att, R_att);
+            obj.attControl = AttQuatControl(J, K_att);
+            
+            % position controller
+            Q_pos = diag([1, 1, 1, 0.1, 0.1, 0.1].^2);
+            R_pos = 1*eye(3);
+            K_pos = PosQuatControl.gain(Q_pos, R_pos);
+            obj.posControl = PosQuatControl(m, K_pos);
+            
+            obj.attachDynSystems({obj.quadrotor});
+        end
+        
+        % implement
+        function forward(obj)
+            p_d = [0; 0; 1];
+            v_d = [0; 0; 0];
+            
+            [p, v, R_iv, omega] = obj.quadrotor.stateValueList{:};
+            q = Orientations.rotationToQuat(R_iv.');
+            
+            [f, q_d, omega_d] = obj.posControl.forward(p, v, p_d, v_d);
+            tau = obj.attControl.forward(q, omega, q_d, omega_d);
+            
+            obj.quadrotor.forward([f; tau]);
+        end
+    end
+end

--- a/multicopter/Quadrotor-Quaternion-Control.md
+++ b/multicopter/Quadrotor-Quaternion-Control.md
@@ -1,0 +1,105 @@
+## Quadrotor Quaternion Control
+
+##### 2021/07/17
+
+The content of this document is based on the following reference:
+
+J. Carino, H. Abaunza and P. Castillo, 2015, "Quadrotor Quaternion Control"
+
+
+
+#### Attitude Control
+
+The axis-angle representation $\overline{\theta}$ can be obtained as $\overline{\theta}=2\ln\boldsymbol{q}$. The attitude dynamic model becomes
+$$
+\begin{align}
+\frac{d}{dt}\begin{bmatrix}
+\overline{\theta} \\ \omega
+\end{bmatrix} &= \begin{bmatrix}
+0_{3\times 3} & I_{3} \\
+0_{3\times 3} & 0_{3\times 3}
+\end{bmatrix}\begin{bmatrix}
+\overline{\theta} \\
+\omega
+\end{bmatrix} + \begin{bmatrix}
+0_{3 \times 3} \\ I_{3}
+\end{bmatrix}u_{att} \\
+&= Ax_{att} + Bu_{att}
+\end{align}
+$$
+where
+$$
+x_{att}=\begin{bmatrix}
+2\ln\boldsymbol{q} \\
+\omega
+\end{bmatrix},\quad \tau = Ju_{att} + \omega \times J\omega
+$$
+The control law for the attitude dynamic is proposed as
+$$
+u_{att}=-K_{att}(x_{att} - x_{att, d})
+$$
+where $x_{att, d}$ is the desired attitude.
+
+
+
+#### Position Control
+
+The position dynamic model becomes
+$$
+\begin{align}
+\frac{d}{dt}\begin{bmatrix}
+p \\ \dot{p}
+\end{bmatrix} &= \begin{bmatrix}
+0_{3\times 3} & I_{3} \\
+0_{3\times 3} & 0_{3\times 3}
+\end{bmatrix}\begin{bmatrix}
+p \\
+\dot{p}
+\end{bmatrix} + \begin{bmatrix}
+0_{3 \times 3} \\ I_{3}
+\end{bmatrix}u_{pos} \\
+&= Ax_{pos} + Bu_{pos}
+\end{align}
+$$
+where
+$$
+x_{pos}=\begin{bmatrix}
+p \\ \dot{p}
+\end{bmatrix}
+$$
+The control law for the position dynamic is proposed as
+$$
+u_{pos}=-K_{pos}(x_{pos} - x_{pos, d})
+$$
+where $x_{pos, d}$ is the desired position.
+
+The total thrust $F_{th}$ can be obtained as
+$$
+\begin{align}
+\quad u_{p,d} &= u_{pos} - \overline{g} \\
+F_{th} &= m \Vert u_{p, d}\Vert
+\end{align}
+$$
+The desired attitude can be obtained as
+$$
+\begin{align}
+\boldsymbol{r}_{d} &= (n\cdot u_{p, d} + \Vert u_{p, d}\Vert) + n \times u_{p, d} \\
+\boldsymbol{q}_{d} &= \frac{\boldsymbol{r}_{d}}{\Vert \boldsymbol{r}_{d}\Vert} \\
+\omega_{d} &= 2\boldsymbol{q}_{d}^{\ast}\dot{\boldsymbol{q}}_{d}
+\end{align}
+$$
+To obtain the expression for $\boldsymbol{q}^{\ast}_{d}$, expressions for $\dot{u}_{p,d}$ and $\dot{\boldsymbol{r}}_{d}$ have to obtained first. Assuming constant $x_{pos, d}$,
+$$
+\dot{u}_{p,d}=\dot{u}_{pos}=-K_{pos}\dot{x}_{pos}=-K_{pos}(Ax_{pos} + Bu_{pos})
+$$
+In addition,
+$$
+\begin{align}
+\dot{\boldsymbol{r}}_{d} &= \left(n\cdot \dot{u}_{p,d} + \frac{u_{p,d}^{T}\dot{u}_{p,d}}{\Vert u_{p,d}\Vert} \right) + n \times \dot{u}_{p,d} \\
+\dot{\boldsymbol{q}_{d}} &= \frac{\dot{\boldsymbol{r}}_{d}}{\Vert \boldsymbol{r}_{d}\Vert} + \boldsymbol{r} \left( -\frac{\boldsymbol{r}_{d}^{T}\dot{\boldsymbol{r}}_{d}}{\Vert \boldsymbol{r}_{d}\Vert^{3}}\right)
+\end{align}
+$$
+
+
+
+

--- a/multicopter/QuadrotorDyn.m
+++ b/multicopter/QuadrotorDyn.m
@@ -133,7 +133,6 @@ classdef QuadrotorDyn < MultiStateDynSystem
                 plot(timeList, rad2deg(eulerAngleList(k, :)))
                 xlabel('Time [s]')
                 ylabel(ylabelList{k})
-                ylim([-180, 180])
                 grid on
                 box on
             end

--- a/multicopter/att_quat_stabilization_simulation.m
+++ b/multicopter/att_quat_stabilization_simulation.m
@@ -1,0 +1,18 @@
+addpath(genpath('../core'))
+addpath(genpath('../lie-algebra'))
+addpath(genpath('./'))
+
+clear
+clc
+close all
+
+dt = 0.01;
+finalTime = 5;
+system = AttQuatStabilization();
+
+Simulator(system).propagate(dt, finalTime, true);
+system.quadrotor.plot();
+
+rmpath(genpath('../core'))
+rmpath(genpath('../lie-algebra'))
+rmpath(genpath('./'))

--- a/multicopter/pos_quat_stabilization_simulation.m
+++ b/multicopter/pos_quat_stabilization_simulation.m
@@ -1,0 +1,18 @@
+addpath(genpath('../core'))
+addpath(genpath('../lie-algebra'))
+addpath(genpath('./'))
+
+clear
+clc
+close all
+
+dt = 0.01;
+finalTime = 10;
+system = PosQuatStabilization();
+
+Simulator(system).propagate(dt, finalTime, true);
+system.quadrotor.plot();
+
+rmpath(genpath('../core'))
+rmpath(genpath('../lie-algebra'))
+rmpath(genpath('./'))


### PR DESCRIPTION
* `AttQuatControl`: A quaternion-based attitude control law.
* `AttQuatStabilization`: A quadrotor dynamic with attitude controller.
* `PosQuatControl`: A quaternion-based position control law.
* `PosQuatStabilization`: A quadrotor dynamic with position and attitude controller.
* Script files have been added to perform numerical simulations.