### PR TITLE
Add 'toLog' method to 'Logger' (#68)

### DIFF
--- a/common/functions/FirstOrderDyn.m
+++ b/common/functions/FirstOrderDyn.m
@@ -28,8 +28,7 @@ classdef FirstOrderDyn < LinearDynFun
             u_step = 1;
             simulator.propagate(0.01, 10, true, u_step);
             
-            history = system.history;
-            [timeList, stateList, inputList] = history.get();
+            [timeList, stateList, inputList] = system.history{:};
             figure();
             hold on
             plot(timeList, inputList, '-', 'DisplayName', 'Reference')

--- a/common/functions/SecondOrderDyn.m
+++ b/common/functions/SecondOrderDyn.m
@@ -33,8 +33,7 @@ classdef SecondOrderDyn < LinearDynFun
             u_step = 1;
             simulator.propagate(0.01, 10, true, u_step);
             
-            history = system.history;
-            [timeList, stateList, inputList] = history.get();
+            [timeList, stateList, inputList] = system.history{:};
             figure();
             hold on
             plot(timeList, inputList, '-', 'DisplayName', 'Reference')

--- a/core/systems/DynSystem.m
+++ b/core/systems/DynSystem.m
@@ -19,7 +19,10 @@ classdef DynSystem < TimeVaryingDynSystem
             % derivFun: function_handle or BaseFunction
             % derivFun(state, input1, ..., inputM)
             obj.stateVar.forward(varargin{:});
-            obj.logger.forward(obj.state, varargin{:});
+            if obj.logger.toLog()
+                obj.logger.forward(obj.state, varargin{:});
+            end
+            
             if nargout > 0
                 out = obj.output;
             end

--- a/core/systems/MultiStateDynSystem.m
+++ b/core/systems/MultiStateDynSystem.m
@@ -65,7 +65,9 @@ classdef MultiStateDynSystem < BaseSystem
         
         % implement
         function out = forward(obj, varargin)
-            obj.logger.forward(obj.stateValueList{:}, varargin{:});
+            if obj.logger.toLog()
+                obj.logger.forward(obj.stateValueList{:}, varargin{:});
+            end
             
             if isa(obj.derivFun, 'BaseFunction')
                 derivList = obj.derivFun.forward(obj.stateValueList{:}, varargin{:});

--- a/core/systems/TimeVaryingDynSystem.m
+++ b/core/systems/TimeVaryingDynSystem.m
@@ -76,7 +76,9 @@ classdef TimeVaryingDynSystem < BaseSystem
             % derivFun: function_handle or BaseFunction
             % derivFun(state, time, input1, ..., inputM)
             obj.stateVar.forward(obj.time, varargin{:});
-            obj.logger.forward(obj.state, varargin{:});
+            if obj.logger.toLog()
+                obj.logger.forward(obj.state, varargin{:});
+            end
             
             if nargout > 0
                 out = obj.output;

--- a/core/utils/Logger.m
+++ b/core/utils/Logger.m
@@ -43,6 +43,15 @@ classdef Logger < handle
         
         function applyTime(obj, timeFeed)
             obj.time = timeFeed;
+            obj.timer.forward(timeFeed);
+        end
+        
+        function out = toLog(obj)
+            if ~isempty(obj.timer)
+                out = obj.timer.checkEvent();
+            else
+                out = false;
+            end
         end
         
         function forward(obj, varargin)
@@ -123,8 +132,10 @@ classdef Logger < handle
             vel = [1; 0];
             for i = 1:100
                 logger.applyTime(time);
-                logger.forward(pos, vel);
-                logger.forwardVarNames('pos', 'vel');
+                if logger.toLog()
+                    logger.forward(pos, vel);
+                    logger.forwardVarNames('pos', 'vel');
+                end
                 
                 pos = pos + vel*dt;
                 time = time + dt;

--- a/missile/PurePNG3dimEngagement.m
+++ b/missile/PurePNG3dimEngagement.m
@@ -32,8 +32,10 @@ classdef PurePNG3dimEngagement < MultipleSystem
             a_M = obj.purePng.forward(R_VL, v_M, omega);
             obj.missile.forward(a_M);
             
-            obj.logger.forward(omega, r);
-            obj.logger.forwardVarNames('losRate', 'range');
+            if obj.logger.toLog()
+                obj.logger.forward(omega, r);
+                obj.logger.forwardVarNames('losRate', 'range');
+            end
         end
         
         % implement


### PR DESCRIPTION
* `toLog` method has been added to `Logger` class to allow checking when to log outside the logger object.
* `applyTime` method of `Logger` class has been modified to update the timer time.
* System classes have been modified to use `toLog` method.
* Minor bug in `FirstOrderDyn` and `SecondOrderDyn` has been fixed.