### PR TITLE
[Core] Add 'correctionFun' to 'Variable' and fix a bug (#70)

### DIFF
--- a/core/systems/BaseSystem.m
+++ b/core/systems/BaseSystem.m
@@ -32,7 +32,7 @@ classdef(Abstract) BaseSystem < handle
         function applyState(obj, stateFeed)
             for k = 1:obj.stateVarNum
                 index = obj.stateIndex{k};
-                obj.stateVarList{k}.flatValue = stateFeed(index, 1);
+                obj.stateVarList{k}.setFlatValue(stateFeed(index, 1));
             end
         end
         

--- a/core/systems/TimeVaryingDynSystem.m
+++ b/core/systems/TimeVaryingDynSystem.m
@@ -50,7 +50,7 @@ classdef TimeVaryingDynSystem < BaseSystem
         
         % override
         function applyState(obj, stateFeed)
-            obj.stateVar.flatValue = stateFeed;
+            obj.stateVar.setFlatValue(stateFeed);
         end
         
         % override

--- a/core/variables/Variable.m
+++ b/core/variables/Variable.m
@@ -1,7 +1,8 @@
 classdef Variable < handle
     properties
-        shape
         value
+        shape
+        correctionFun
     end
     properties(Dependent)
         flatValue
@@ -9,24 +10,41 @@ classdef Variable < handle
     
     methods
         function obj = Variable(value)
-            obj.shape = size(value);
             obj.value = value;
+            obj.shape = size(value);
         end
         
+        % implement
         function out = numel(obj)
             out = prod(obj.shape);
+        end
+        
+        function attachCorrectionFun(obj, correctionFun)
+            % correctionFun is a function_handle
+            obj.correctionFun = correctionFun;
         end
     end
     % Set and get methods
     methods
+        function setValue(obj, value)
+            if ~isempty(obj.correctionFun)
+                value = obj.correctionFun(value);
+            end
+            obj.value = value;
+        end
+        
+        function setFlatValue(obj, flatValue)
+            assert(numel(flatValue) == numel(obj),...
+                "The number of elements does not match.")
+            setValue(obj, reshape(flatValue, obj.shape));
+        end
+        
         function out = get.flatValue(obj)
             out = reshape(obj.value, [], 1);
         end
         
         function set.flatValue(obj, flatValue)
-            assert(numel(flatValue) == numel(obj),...
-                "The number of elements does not match.")
-            obj.value = reshape(flatValue, obj.shape);
+            setFlatValue(obj, flatValue);
         end
     end
     methods(Static)

--- a/missile/model/ManeuvVehicle3dof.m
+++ b/missile/model/ManeuvVehicle3dof.m
@@ -18,6 +18,13 @@ classdef ManeuvVehicle3dof < DynSystem
     methods
         function obj = ManeuvVehicle3dof(initialState)
             obj = obj@DynSystem(initialState);
+            
+            function stateFeed = angleCorrectionFun(stateFeed)
+                % gamma should be in [-pi, pi] rad
+                % chi should be in [-pi, pi] rad
+                stateFeed(5:6) = ManeuvVehicle3dof.wrapToPi(stateFeed(5:6));
+            end
+            obj.stateVar.attachCorrectionFun(@angleCorrectionFun);
         end
         
         % override
@@ -38,14 +45,6 @@ classdef ManeuvVehicle3dof < DynSystem
             chi_dot = a_y/(V*cos(gamma));
             
             out = [p_n_dot; p_e_dot; p_d_dot; V_dot; gamma_dot; chi_dot];
-        end
-        
-        % override
-        function applyState(obj, stateFeed)
-            % gamma should be in [-pi, pi] rad
-            % chi should be in [-pi, pi] rad
-            stateFeed(5:6) = ManeuvVehicle3dof.wrapToPi(stateFeed(5:6));
-            applyState@DynSystem(obj, stateFeed);
         end
         
         function out = get.pos(obj)

--- a/multicopter/model/QuadrotorDyn.m
+++ b/multicopter/model/QuadrotorDyn.m
@@ -11,6 +11,15 @@ classdef QuadrotorDyn < MultiStateDynSystem
             obj = obj@MultiStateDynSystem(initialState);
             obj.m = m;
             obj.J = J;
+            
+            function R = rotationCorrectionFun(R)
+                % rotation matrix should be orthogonal
+                isOrthogonal = Orientations.checkOrthogonality(R);
+                if ~isOrthogonal
+                    R = Orientations.correctOrthogonality(R);
+                end
+            end
+            obj.stateVarList{3}.attachCorrectionFun(@rotationCorrectionFun);
         end
         
         % override
@@ -29,19 +38,6 @@ classdef QuadrotorDyn < MultiStateDynSystem
             omega_dot = obj.J\(-cross(omega, obj.J*omega) + tau);
             
             out = {p_dot, v_dot, R_dot, omega_dot};
-        end
-        
-        % override
-        function applyState(obj, stateFeed)
-            % rotation matrix should be orthogonal
-            applyState@MultiStateDynSystem(obj, stateFeed);
-            R = obj.stateVarList{3}.value;
-            isOrthogonal = Orientations.checkOrthogonality(R);
-            if ~isOrthogonal
-                obj.stateVarList{3}.value = ...
-                    Orientations.correctOrthogonality(R);
-            end
-            
         end
         
         function figs = plot(obj, figs)


### PR DESCRIPTION
* `setValue` and `setFlatValue` methods have been added to `Variable` class.
* `correctionFun` property has been added to `Variable` class. `correctionFun` is used to correct or process an input value before assigning it to `value` of the variable.
* `applyState` method of `BaseSystem` and `TimeVaryingDynSystem` class has been modified to use `setFlatValue` method.
* As examples, `angleCorrectionFun` has been added to `ManeuvVehicle3dof` system and `rotationCorrectionFun` has been added to `QuadrotorDyn` system.