### PR TITLE
Import matlab-deriv-operation as a submodule (#76)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lie-algebra"]
 	path = lie-algebra
 	url = https://github.com/Solar-lemon/lie-algebra.git
+[submodule "matlab-deriv-operation"]
+	path = matlab-deriv-operation
+	url = https://github.com/Solar-lemon/matlab-deriv-operation.git


### PR DESCRIPTION
`matlab-deriv-operation` at https://github.com/Solar-lemon/matlab-deriv-operation.git has been added as a submodule