### PR TITLE
[Core] Enable passing time variable input to propagate method of Simulator (#79)

### DIFF
--- a/core/simulator/Simulator.m
+++ b/core/simulator/Simulator.m
@@ -16,14 +16,13 @@ classdef Simulator < handle
         end
         
         function finishLogging(obj)
-            obj.system.forward(obj.inValues{:});
+            obj.system.forwardWrapper(obj.inValues);
             obj.system.finishLogging();
         end
         
         function step(obj, dt, varargin)
-            obj.inValues = varargin;
             if ~obj.initialized
-                obj.system.forward(varargin{:});
+                obj.system.forwardWrapper(varargin);
                 obj.initialized = true;
             end
             
@@ -43,6 +42,8 @@ classdef Simulator < handle
             y = y0 + dt*(k1 + 2*k2 + 2*k3 + k4)/6;
             obj.system.applyTime(t);
             obj.system.applyState(y);
+            
+            obj.inValues = varargin;
         end
         
         function propagate(obj, dt, time, saveHistory, varargin)
@@ -50,10 +51,8 @@ classdef Simulator < handle
                 saveHistory = false;
             end
             
-            obj.inValues = varargin;
-            
             if ~obj.initialized
-                obj.system.forward(varargin{:});
+                obj.system.forwardWrapper(varargin);
                 obj.initialized = true;
             end
             
@@ -83,6 +82,7 @@ classdef Simulator < handle
             obj.system.applyTime(t);
             obj.system.applyState(y);
             
+            obj.inValues = varargin;
             obj.finishLogging();
         end
     end

--- a/core/systems/TimeVaryingDynSystem.m
+++ b/core/systems/TimeVaryingDynSystem.m
@@ -57,9 +57,9 @@ classdef TimeVaryingDynSystem < BaseSystem
         function out = stateDeriv(obj, stateFeed, timeFeed, varargin)
             % Assume that stateFeed and timeFeed are always given
             % together
-            applyState(obj, stateFeed);
-            applyTime(obj, timeFeed);
-            forward(obj, varargin{:});
+            obj.applyState(stateFeed);
+            obj.applyTime(timeFeed);
+            obj.forwardWrapper(varargin);
             
             out = obj.stateVar.flatDeriv;
         end

--- a/examples/dyn_system_example.m
+++ b/examples/dyn_system_example.m
@@ -1,7 +1,11 @@
 clear
 clc
 close all
+
 addpath(genpath('../core'))
+addpath(genpath('../common'))
+set(0,'DefaultFigureWindowStyle','docked')
+
 fprintf('== Test for SecondOrderDynSystem == \n')
 
 zeta = 0.5;
@@ -55,4 +59,20 @@ fig3 = figure();
 sgtitle('class inheritance')
 system3.plot(fig3);
 
+% Time varying input test
+fprintf("Time varying input test \n")
+u_varying = @(t) sin(2*pi*t/10);
+tic
+system4 = SecondOrderDynSystem([0; 0], zeta, omega);
+Simulator(system4).propagate(dt, finalTime, true, u_varying);
+elapsedTime = toc;
+
+fprintf("Elapsed time: %.2f [s] \n\n", elapsedTime);
+
+fig4 = figure();
+sgtitle('time varying input')
+system4.plot(fig4);
+
 rmpath(genpath('../core'))
+rmpath(genpath('../common'))
+set(0,'DefaultFigureWindowStyle','normal')

--- a/multicopter/geo_att_tracking_simulation.m
+++ b/multicopter/geo_att_tracking_simulation.m
@@ -13,8 +13,10 @@ dt = 0.01;
 finalTime = 5;
 simulation = GeoAttTracking(testMode);
 
+trajFun = DiscreteFunction(@trajectory, 1/100); % 100 [Hz]
+
 tic
-Simulator(simulation).propagate(dt, finalTime, true);
+Simulator(simulation).propagate(dt, finalTime, true, trajFun);
 elapsedTime = toc;
 
 simulation.quadrotor.plot();
@@ -25,3 +27,13 @@ rmpath(genpath('../core'))
 rmpath(genpath('../lie-algebra'))
 rmpath(genpath('../matlab-deriv-operation'))
 rmpath(genpath('./'))
+
+function R_d = trajectory(time)
+t = IndepVariable(time, 1);
+phi = 0.1*sin(2*pi*t/5);
+theta = 0.1*sin(2*pi*t/10);
+psi = 0.1*t;
+
+R_d = Orientations.eulerAnglesToRotation(phi, theta, psi).';
+end
+                    

--- a/multicopter/model/QuadrotorDyn.m
+++ b/multicopter/model/QuadrotorDyn.m
@@ -41,6 +41,7 @@ classdef QuadrotorDyn < MultiStateDynSystem
         end
         
         function figs = plot(obj, figs)
+            set(0,'DefaultFigureWindowStyle','docked')
             if nargin < 2
                 figs = cell(7, 1);
                 for k = 1:7
@@ -62,6 +63,7 @@ classdef QuadrotorDyn < MultiStateDynSystem
             end
             
             figure(figs{1});
+            figs{1}.Name = 'Position';
             sgtitle('Position')
             ylabelList = {'x [m]', 'y [m]', 'z [m]'};
             for k = 1:3
@@ -75,6 +77,7 @@ classdef QuadrotorDyn < MultiStateDynSystem
             end
             
             figure(figs{2});
+            figs{2}.Name = 'Velocity';
             sgtitle('Velocity')
             ylabelList = {'v_x [m/s]', 'v_y [m/s]', 'v_z [m/s]'};
             for k = 1:3
@@ -88,6 +91,7 @@ classdef QuadrotorDyn < MultiStateDynSystem
             end
             
             figure(figs{3});
+            figs{3}.Name = 'Rotation matrix';
             sgtitle('Rotation matrix')
             for j = 1:3
                 subplot(3, 1, j)
@@ -105,6 +109,7 @@ classdef QuadrotorDyn < MultiStateDynSystem
             end
             
             figure(figs{4});
+            figs{4}.Name = 'Quaternion';
             sgtitle('Quaternion')
             hold on
             for k = 1:4
@@ -119,6 +124,7 @@ classdef QuadrotorDyn < MultiStateDynSystem
             legend()
             
             figure(figs{5});
+            figs{5}.Name = 'Euler angles';
             sgtitle('Euler angles')
             ylabelList = {'phi [deg]', 'theta [deg]', 'psi [deg]'};
             for k = 1:3
@@ -132,6 +138,7 @@ classdef QuadrotorDyn < MultiStateDynSystem
             end
             
             figure(figs{6});
+            figs{6}.Name = 'Angular velocity';
             sgtitle('Angular velocity')
             ylabelList = {'omega_x [deg/s]', 'omega_y [deg/s]', 'omega_z [deg/s]'};
             for k = 1:3
@@ -145,6 +152,7 @@ classdef QuadrotorDyn < MultiStateDynSystem
             end
             
             figure(figs{7});
+            figs{7}.Name = 'Control input';
             sgtitle('Control input')
             ylabelList = {'f [N]', 'tau_x [N*m]', 'tau_y [N*m]', 'tau_z [N*m]'};
             for k = 1:4
@@ -156,6 +164,7 @@ classdef QuadrotorDyn < MultiStateDynSystem
                 grid on
                 box on
             end
+            set(0,'DefaultFigureWindowStyle','normal')
         end
     end
     


### PR DESCRIPTION
* `forwardWrapper` method has been added to `BaseSystem` class, which performs an appropriate action according to the type of inputs before passing inputs to `forward` method.
* `Simulator` class has been modified to use `forwardWrapper` method instead of `forward` method.
* An example code and geometric attitude control simulation code have been modified.