### PR TITLE
[Core] Move integration part to each state variable (#30)

### DIFF
--- a/core/simulator/Simulator.m
+++ b/core/simulator/Simulator.m
@@ -22,14 +22,10 @@ classdef Simulator < handle
         function step(obj, dt, varargin)
             t0 = obj.system.time;
             
-            obj.system.forwardWrapper(varargin);
-            obj.system.rk4Update1(t0, dt);
-            obj.system.forwardWrapper(varargin);
-            obj.system.rk4Update2(t0, dt);
-            obj.system.forwardWrapper(varargin);
-            obj.system.rk4Update3(t0, dt);
-            obj.system.forwardWrapper(varargin);
-            obj.system.rk4Update4(t0, dt);
+            obj.system.rk4Update1(t0, dt, varargin);
+            obj.system.rk4Update2(t0, dt, varargin);
+            obj.system.rk4Update3(t0, dt, varargin);
+            obj.system.rk4Update4(t0, dt, varargin);
             
             obj.inValues = varargin;
         end
@@ -46,14 +42,10 @@ classdef Simulator < handle
             for i = 1:iterNum
                 t0 = obj.system.time;
                 
-                obj.system.forwardWrapper(varargin);
-                obj.system.rk4Update1(t0, dt);
-                obj.system.forwardWrapper(varargin);
-                obj.system.rk4Update2(t0, dt);
-                obj.system.forwardWrapper(varargin);
-                obj.system.rk4Update3(t0, dt);
-                obj.system.forwardWrapper(varargin);
-                obj.system.rk4Update4(t0, dt);
+                obj.system.rk4Update1(t0, dt, varargin);
+                obj.system.rk4Update2(t0, dt, varargin);
+                obj.system.rk4Update3(t0, dt, varargin);
+                obj.system.rk4Update4(t0, dt, varargin);
                 
                 toStop = obj.system.checkStopCondition();
                 if toStop

--- a/core/systems/BaseSystem.m
+++ b/core/systems/BaseSystem.m
@@ -67,28 +67,32 @@ classdef(Abstract) BaseSystem < handle
             obj.forward(inputsToForward{:});
         end
         
-        function rk4Update1(obj, t0, dt)
+        function rk4Update1(obj, t0, dt, inValues)
+            obj.forwardWrapper(inValues);
             for k = 1:obj.stateVarNum
                 obj.stateVarList{k}.rk4Update1(dt);
             end
             obj.applyTime(t0 + dt/2);
         end
         
-        function rk4Update2(obj, t0, dt)
+        function rk4Update2(obj, t0, dt, inValues)
+            obj.forwardWrapper(inValues);
             for k = 1:obj.stateVarNum
                 obj.stateVarList{k}.rk4Update2(dt);
             end
             obj.applyTime(t0 + dt/2);
         end
         
-        function rk4Update3(obj, t0, dt)
+        function rk4Update3(obj, t0, dt, inValues)
+            obj.forwardWrapper(inValues);
             for k = 1:obj.stateVarNum
                 obj.stateVarList{k}.rk4Update3(dt);
             end
             obj.applyTime(t0 + dt - 10*eps(t0 + dt/2));
         end
         
-        function rk4Update4(obj, t0, dt)
+        function rk4Update4(obj, t0, dt, inValues)
+            obj.forwardWrapper(inValues);
             for k = 1:obj.stateVarNum
                 obj.stateVarList{k}.rk4Update4(dt);
             end

--- a/core/systems/BaseSystem.m
+++ b/core/systems/BaseSystem.m
@@ -41,13 +41,7 @@ classdef(Abstract) BaseSystem < handle
             obj.logger.applyTime(timeFeed);
         end
         
-        function out = stateDeriv(obj, stateFeed, timeFeed, varargin)
-            % Assume that stateFeed and timeFeed are always given
-            % together
-            obj.applyState(stateFeed);
-            obj.applyTime(timeFeed);
-            obj.forwardWrapper(varargin);
-            
+        function out = flatDeriv(obj)
             out = nan(obj.stateNum, 1);
             for k = 1:obj.stateVarNum
                 stateVar = obj.stateVarList{k};
@@ -71,6 +65,34 @@ classdef(Abstract) BaseSystem < handle
                 end
             end
             obj.forward(inputsToForward{:});
+        end
+        
+        function rk4Update1(obj, t0, dt)
+            for k = 1:obj.stateVarNum
+                obj.stateVarList{k}.rk4Update1(dt);
+            end
+            obj.applyTime(t0 + dt/2);
+        end
+        
+        function rk4Update2(obj, t0, dt)
+            for k = 1:obj.stateVarNum
+                obj.stateVarList{k}.rk4Update2(dt);
+            end
+            obj.applyTime(t0 + dt/2);
+        end
+        
+        function rk4Update3(obj, t0, dt)
+            for k = 1:obj.stateVarNum
+                obj.stateVarList{k}.rk4Update3(dt);
+            end
+            obj.applyTime(t0 + dt - 10*eps(t0 + dt/2));
+        end
+        
+        function rk4Update4(obj, t0, dt)
+            for k = 1:obj.stateVarNum
+                obj.stateVarList{k}.rk4Update4(dt);
+            end
+            obj.applyTime(t0 + dt);
         end
         
         function startLogging(obj, logTimeInterval)

--- a/core/systems/MultiStateDynSystem.m
+++ b/core/systems/MultiStateDynSystem.m
@@ -37,7 +37,7 @@ classdef MultiStateDynSystem < BaseSystem
             end
             reset@BaseSystem(obj);
             for k = 1:obj.stateVarNum
-                obj.stateVarList{k}.value = initialState{k};
+                obj.stateVarList{k}.setValue(initialState{k});
             end
         end
         

--- a/core/systems/MultipleSystem.m
+++ b/core/systems/MultipleSystem.m
@@ -75,14 +75,6 @@ classdef MultipleSystem < BaseSystem
         end
         
         % override
-        function out = stateDeriv(obj, stateFeed, timeFeed, varargin)
-            assert(~isempty(obj.systemList), 'Attach dynamic systems first')
-            
-            applyTime(obj, timeFeed);
-            out = stateDeriv@BaseSystem(obj, stateFeed, timeFeed, varargin{:});
-        end
-        
-        % override
         function startLogging(obj, logTimeInterval)
             startLogging@BaseSystem(obj, logTimeInterval);
             for k = 1:obj.systemNum
@@ -100,6 +92,8 @@ classdef MultipleSystem < BaseSystem
         
         % to be implemented
         function forward(obj, varargin)
+            assert(~isempty(obj.systemList),...
+                "Attach dynamic systems first")
             for k = 1:numel(obj.systemList)
                 obj.systemList{k}.forward(varargin{:});
             end

--- a/core/systems/MultipleSystem.m
+++ b/core/systems/MultipleSystem.m
@@ -95,7 +95,7 @@ classdef MultipleSystem < BaseSystem
             assert(~isempty(obj.systemList),...
                 "Attach dynamic systems first")
             for k = 1:numel(obj.systemList)
-                obj.systemList{k}.forward(varargin{:});
+                obj.systemList{k}.forwardWrapper(varargin);
             end
         end
         

--- a/core/systems/TimeVaryingDynSystem.m
+++ b/core/systems/TimeVaryingDynSystem.m
@@ -54,25 +54,29 @@ classdef TimeVaryingDynSystem < BaseSystem
         end
         
         % override
-        function rk4Update1(obj, t0, dt)
+        function rk4Update1(obj, t0, dt, inValues)
+            obj.forwardWrapper(inValues);
             obj.stateVar.rk4Update1(dt);
             obj.applyTime(t0 + dt/2);
         end
         
         % override
-        function rk4Update2(obj, t0, dt)
+        function rk4Update2(obj, t0, dt, inValues)
+            obj.forwardWrapper(inValues);
             obj.stateVar.rk4Update2(dt);
             obj.applyTime(t0 + dt/2);
         end
         
         % override
-        function rk4Update3(obj, t0, dt)
+        function rk4Update3(obj, t0, dt, inValues)
+            obj.forwardWrapper(inValues);
             obj.stateVar.rk4Update3(dt);
             obj.applyTime(t0 + dt - 10*eps(t0 + dt/2));
         end
         
         % override
-        function rk4Update4(obj, t0, dt)
+        function rk4Update4(obj, t0, dt, inValues)
+            obj.forwardWrapper(inValues);
             obj.stateVar.rk4Update4(dt);
             obj.applyTime(t0 + dt);
         end

--- a/core/systems/TimeVaryingDynSystem.m
+++ b/core/systems/TimeVaryingDynSystem.m
@@ -54,13 +54,31 @@ classdef TimeVaryingDynSystem < BaseSystem
         end
         
         % override
-        function out = stateDeriv(obj, stateFeed, timeFeed, varargin)
-            % Assume that stateFeed and timeFeed are always given
-            % together
-            obj.applyState(stateFeed);
-            obj.applyTime(timeFeed);
-            obj.forwardWrapper(varargin);
-            
+        function rk4Update1(obj, t0, dt)
+            obj.stateVar.rk4Update1(dt);
+            obj.applyTime(t0 + dt/2);
+        end
+        
+        % override
+        function rk4Update2(obj, t0, dt)
+            obj.stateVar.rk4Update2(dt);
+            obj.applyTime(t0 + dt/2);
+        end
+        
+        % override
+        function rk4Update3(obj, t0, dt)
+            obj.stateVar.rk4Update3(dt);
+            obj.applyTime(t0 + dt - 10*eps(t0 + dt/2));
+        end
+        
+        % override
+        function rk4Update4(obj, t0, dt)
+            obj.stateVar.rk4Update4(dt);
+            obj.applyTime(t0 + dt);
+        end
+        
+        % override
+        function out = flatDeriv(obj)
             out = obj.stateVar.flatDeriv;
         end
         

--- a/core/variables/StateVariable.m
+++ b/core/variables/StateVariable.m
@@ -3,6 +3,7 @@ classdef StateVariable < Variable
         useBaseFunction
         derivFun
         deriv
+        rk4Buffer
     end
     properties(Dependent)
         flatDeriv
@@ -15,6 +16,8 @@ classdef StateVariable < Variable
             if nargin > 1
                 attachDerivFun(obj, derivFun);
             end
+            obj.rk4Buffer = cell(1, 5); % rk4Buffer = {x0, k1, k2, k3, k4}
+            obj.rk4Buffer{1} = obj.flatValue;
         end
         
         function attachDerivFun(obj, derivFun)
@@ -28,6 +31,37 @@ classdef StateVariable < Variable
             else
                 obj.deriv = obj.derivFun(obj.value, varargin{:});
             end
+        end
+        
+        function rk4Update1(obj, dt)
+            obj.rk4Buffer{1} = obj.flatValue; % y0
+            obj.rk4Buffer{2} = obj.flatDeriv; % k1
+            obj.setFlatValue(...
+                obj.rk4Buffer{1} + dt/2*obj.rk4Buffer{2});
+            % y = y0 + dt/2*k1
+        end
+        
+        function rk4Update2(obj, dt)
+            obj.rk4Buffer{3} = obj.flatDeriv; % k2
+            obj.setFlatValue(...
+                obj.rk4Buffer{1} + dt/2*obj.rk4Buffer{3});
+            % y = y0 + dt/2*k2
+        end
+        
+        function rk4Update3(obj, dt)
+            obj.rk4Buffer{4} = obj.flatDeriv; % k3
+            obj.setFlatValue(...
+                obj.rk4Buffer{1} + dt*obj.rk4Buffer{4});
+            % y = y0 + dt*k3
+        end
+        
+        function rk4Update4(obj, dt)
+            obj.rk4Buffer{5} = obj.flatDeriv; % k4
+            [y0, k1, k2, k3, k4] = obj.rk4Buffer{:};
+            y = y0 + dt*(k1 + 2*k2 + 2*k3 + k4)/6;
+            
+            obj.setFlatValue(y);
+            obj.rk4Buffer{1} = y;
         end
     end
     % Set and get methods

--- a/multicopter/AttQuatStabilization.m
+++ b/multicopter/AttQuatStabilization.m
@@ -40,7 +40,7 @@ classdef AttQuatStabilization < MultipleSystem
             omega = quadState{4};
             q = Orientations.rotationToQuat(R_iv.');
             
-            f = obj.quadrotor.m*obj.quadrotor.g;
+            f = obj.quadrotor.m*FlatEarthEnv.gravAccel;
             tau = obj.attControl.forward(q, omega, q_d, omega_d);
             
             obj.quadrotor.forward([f; tau]);

--- a/multicopter/att_quat_stabilization_simulation.m
+++ b/multicopter/att_quat_stabilization_simulation.m
@@ -1,4 +1,5 @@
 addpath(genpath('../core'))
+addpath(genpath('../common'))
 addpath(genpath('../lie-algebra'))
 addpath(genpath('./'))
 
@@ -14,5 +15,6 @@ Simulator(system).propagate(dt, finalTime, true);
 system.quadrotor.plot();
 
 rmpath(genpath('../core'))
+rmpath(genpath('../common'))
 rmpath(genpath('../lie-algebra'))
 rmpath(genpath('./'))

--- a/multicopter/pos_quat_stabilization_simulation.m
+++ b/multicopter/pos_quat_stabilization_simulation.m
@@ -1,4 +1,5 @@
 addpath(genpath('../core'))
+addpath(genpath('../common'))
 addpath(genpath('../lie-algebra'))
 addpath(genpath('./'))
 
@@ -14,5 +15,6 @@ Simulator(system).propagate(dt, finalTime, true);
 system.quadrotor.plot();
 
 rmpath(genpath('../core'))
+rmpath(genpath('../common'))
 rmpath(genpath('../lie-algebra'))
 rmpath(genpath('./'))


### PR DESCRIPTION
* `rk4Buffer` property has been added to `StateVariable` to record the intermediate values for Runge-Kutta 4th order integration.
* `rk4Update` methods for Runge-Kutta 4th order integration have been added to `StateVariable` and system classes.
* `stateDeriv` methods have been removed from system classes and `flatDeriv` methods replaced `stateDeriv` methods. Compared to the previous `stateDeriv` methods, `flatDeriv` methods are not intended to be used for any integration.
* `Simulator` class has been modified to use `rk4Update` methods when performing a simulation.