### PR TITLE
[Core] Add ParallelSimulator (#84)

### DIFF
--- a/core/simulator/ParallelSimulator.m
+++ b/core/simulator/ParallelSimulator.m
@@ -1,0 +1,107 @@
+classdef ParallelSimulator < handle
+    properties
+        data
+        paramLists
+        paramSetList
+        totalSimNum
+        simulationFun
+    end
+    methods
+        function obj = ParallelSimulator()
+            obj.data = MatStackedData();
+            obj.attachSimulationFun();
+        end
+        
+        function attachParamLists(obj, varargin)
+            % For example, assume that we have
+            % k possible choices for parameter a,
+            % l possible choices for parameter b,
+            % m possible choices for parameter c.
+            % Then
+            % varargin = {paramAList, paramBList, paramCList}
+            % where
+            % paramAList = [a_1, ..., a_k] (d_1xk matrix) or {a_1, ..., a_k},
+            % paramBList = [b_1, ..., b_l] (d_2xl matrix) or {b_1, ..., b_l},
+            % paramCList = [c_1, ..., c_m] (d_3xm matrix) or {c_1, ..., c_m}
+            % paramNums = [k, l, m];
+            
+            obj.paramLists = varargin;
+            
+            N = numel(varargin);
+            paramNums = nan(1, N);
+            for n = 1:N
+                paramNums(n) = numel(varargin{n});
+            end
+            obj.totalSimNum = prod(paramNums);
+            
+            obj.paramSetList = cell(1, obj.totalSimNum);
+            for i = 1:obj.totalSimNum
+                subs = cell(1, N);
+                [subs{:}] = ind2sub(paramNums, i);
+                paramSet = cell(1, N);
+                for n = 1:N
+                    if isa(varargin{n}, 'numeric')
+                        paramSet{n} = varargin{n}(:, subs{n});
+                    else
+                        paramSet{n} = varargin{n}{subs{n}};
+                    end
+                end
+                obj.paramSetList{i} = paramSet;
+            end
+        end
+        
+        function attachSimulationFun(obj, simulationFun)
+            % output of the simulationFun should be simulation data with
+            % the type of structure.
+            if nargin < 2 || isempty(simulationFun)
+                simulationFun = @obj.simulateModel;
+            end
+            obj.simulationFun = simulationFun;
+        end
+        
+        function simulate(obj)
+            pool = gcp;
+            numWorkers = pool.NumWorkers;
+            
+            tempData = cell(1, obj.totalSimNum);
+            parfor (i = 1:obj.totalSimNum, numWorkers)
+                fprintf("=== %d-th simulation === \n", i)
+                paramSet = obj.paramSetList{i};
+                tempData{i} = obj.simulationFun(i, paramSet{:});
+            end
+            
+            if ~isempty(tempData{1})
+                fields = fieldnames(tempData{1});
+                obj.data.setVarNames(fields{:});
+                for i = 1:obj.totalSimNum
+                    simData = struct2cell(tempData{i});
+                    obj.data.append(simData{:});
+                end
+            end
+        end
+        
+        function out = getDataByVarNames(obj, varargin)
+            out = obj.data.matValuesByVarNames(varargin{:});
+        end
+        
+        function save(obj, filePath)
+            if nargin < 2 || isempty(filePath)
+                if ~isfolder("data")
+                    mkdir("data")
+                end
+                if ~isfolder("data/parSim")
+                    mkdir("data/parSim")
+                end
+                filePath = "data/parSim/data.mat";
+            end
+            obj.data.save(filePath);
+        end
+        
+        % to be implemented
+        function model = simulateModel(obj, i)
+            % implement this method if needed
+            fprintf("Attach a modelGeneratingFun or implement generateModel method! \n")
+        end
+    end
+end
+        

--- a/examples/par_sim_example.m
+++ b/examples/par_sim_example.m
@@ -1,0 +1,57 @@
+clear
+clc
+close all
+
+addpath(genpath('../core'))
+addpath(genpath('../common'))
+
+fprintf("== Test for ParallelSimulator ==\n")
+zetaList = 0.2:0.2:1.0;
+omegaList = 1:10;
+
+tic
+parSimulator = ParallelSimulator();
+parSimulator.attachParamLists(zetaList, omegaList);
+parSimulator.attachSimulationFun(@simulationFun);
+parSimulator.simulate();
+parSimulator.save();
+elapsedTime = toc;
+
+fprintf("ElapsedTime: %.2f [s] \n", elapsedTime);
+fprintf("The average time taken for each simulation: %.2f [s] \n",...
+    elapsedTime/parSimulator.totalSimNum);
+
+data = parSimulator.getDataByVarNames('zeta', 'omega', 'overshoot');
+[zeta, omega, overshoot] = data{:};
+numColor = 16;
+offset = 1;
+c = overshoot - min(overshoot);
+c = round((numColor - 1 - 2*offset)*c/max(c) + 1 + offset);
+
+figure();
+hold on
+scatter3(zeta, omega, overshoot, 30, c, 'filled')
+view([30, 35])
+xlabel('Zeta')
+ylabel('Omega')
+zlabel('Overshoot (%)')
+grid on
+box on
+colorbar('Location', 'EastOutside')
+
+rmpath(genpath('../core'))
+rmpath(genpath('../common'))
+
+function simData = simulationFun(i, zeta, omega)
+model = SecondOrderDynSystem([0; 0], zeta, omega);
+model.name = ['model_', num2str(i)];
+
+u_step = 1;
+Simulator(model).propagate(0.01, 100, true, u_step);
+stateList = model.history{2};
+overshoot = max(stateList(1, :) - u_step)/u_step*100;
+
+simData.zeta = zeta;
+simData.omega = omega;
+simData.overshoot = overshoot;
+end


### PR DESCRIPTION
`Simulator` has been slightly modified
* Unnecessary `stateNum` variable in `Simulator` has been removed.
* The position of codes for checking stop conditions in `Simulator` has been modified.

`ParallelSimulator` has been added for performing multiple simulations with different parameters.
* To use `ParallelSimulator`, `paramLists` must be passed to the object.
* To use `ParallelSimulator`, `simulationFcn` must be passed to the object (or `simulateModel` method should be implemented).

Refer to the example file for the details.