### PR TITLE
[Core] Add simulateSingle method to ParallelSimulator

### DIFF
--- a/core/systems/BaseSystem.m
+++ b/core/systems/BaseSystem.m
@@ -125,6 +125,16 @@ classdef(Abstract) BaseSystem < handle
                 flag = obj.flag;
             end
         end
+        
+        % to be implemented
+        function plot(obj)
+            
+        end
+        
+        % to be implemented
+        function report(obj)
+            
+        end
     end
     
     methods

--- a/examples/par_sim_example.m
+++ b/examples/par_sim_example.m
@@ -12,6 +12,7 @@ omegaList = 1:10;
 parSimulator = ParallelSimulator();
 parSimulator.attachParamLists(zetaList, omegaList);
 parSimulator.attachSimulationFun(@simulationFun);
+parSimulator.simulateSingle(0.4, 1);
 parSimulator.simulate();
 parSimulator.save();
 
@@ -36,7 +37,7 @@ colorbar('Location', 'EastOutside')
 rmpath(genpath('../core'))
 rmpath(genpath('../common'))
 
-function simData = simulationFun(i, zeta, omega)
+function [simData, model] = simulationFun(i, zeta, omega)
 model = SecondOrderDynSystem([0; 0], zeta, omega);
 model.name = ['model_', num2str(i)];
 


### PR DESCRIPTION
`simulateSingle` method has been added to `ParallelSimulator`.
The method calls `plot` and `report` method of the simulated model by default.