### PR TITLE
Add files for BOMIACG (#115)

### DIFF
--- a/missile/BOMIACGEngagement.m
+++ b/missile/BOMIACGEngagement.m
@@ -1,0 +1,42 @@
+classdef BOMIACGEngagement < Engagement2dim
+    properties
+        bomiaccg
+    end
+    methods
+        function obj = BOMIACGEngagement(missile, target, gamma_d)
+            obj = obj@Engagement2dim(missile, target);
+            
+            sigma_max = missile.fovLimit;
+            obj.bomiaccg = DiscreteFunction(...
+                BOMIACG(gamma_d, sigma_max, 10, 0.5, 0.15), 1/40); % 40Hz
+            
+            obj.attachDiscSystems({obj.bomiaccg});
+        end
+        
+        % implement
+        function forward(obj)
+            forward@Engagement2dim(obj);
+            v_M = obj.missile.speed;
+            sigma_M = obj.missile.lookAngle();
+            lam = obj.kinematics.losAngle;
+            
+            a_M = obj.bomiaccg.forward(v_M, sigma_M, lam);
+            obj.missile.forward([0; a_M]);
+        end
+        
+        function out = impactAngle(obj)
+            rangeList = obj.historyByVarNames('r');
+            [~, index] = min(rangeList);
+            
+            state_M = obj.missile.history{2};
+            out = state_M(4, index);
+        end
+        
+        % override
+        function report(obj)
+            report@Engagement2dim(obj);
+            fprintf("[Engagement] Impact angle: %.2f [deg] \n",...
+                rad2deg(obj.impactAngle()))
+        end
+    end
+end

--- a/missile/bomiacg_2dim_engagement_simulation.m
+++ b/missile/bomiacg_2dim_engagement_simulation.m
@@ -1,0 +1,31 @@
+addpath(genpath('../core'))
+addpath(genpath('../common'))
+addpath(genpath('./'))
+
+clear
+clc
+close all
+
+fprintf("== Two dimensional BOMIACG engagement for a stationary target == \n")
+
+dt = 0.005;
+finalTime = 100;
+
+missile = PlanarMissile3dof(...
+    [0; 0; 250; deg2rad(15)]);
+missile.fovLimit = deg2rad(30);
+missile.accLimit = ...
+    [-inf, inf;
+    -10*FlatEarthEnv.gravAccel, FlatEarthEnv.gravAccel];
+target = PlanarNonManeuvVehicle3dof(...
+    [10E3; 0; 0; 0]);
+gamma_d = deg2rad(-60);
+
+model = BOMIACGEngagement(missile, target, gamma_d);
+Simulator(model).propagate(dt, finalTime, true);
+model.plot();
+model.report();
+
+rmpath(genpath('../core'))
+rmpath(genpath('../common'))
+rmpath(genpath('./'))

--- a/missile/guidance/BOMIACG.m
+++ b/missile/guidance/BOMIACG.m
@@ -1,0 +1,46 @@
+classdef BOMIACG < BaseFunction
+    % Reference: H. Kim, Look Angle Constrained Impact Angle Control
+    % Guidance Law for Homing Missiles With Bearings-Only Measurements,
+    % 2018, IEEE Transactions on Aerospace and Electronic Systems
+    properties
+        % gamma_d: the desired final flight path angle of the missile
+        % k_1, phi: design parameters for the sliding surface
+        % 0 < k_1 < sigma_max, phi > 0
+        % R_f: the acceptable maximum miss distance
+        % k_2, a: a design parameter for the sliding mode control
+        gamma_d
+        k_1
+        k_2
+        R_f
+        phi
+        a = 0.1
+    end
+    methods
+        function obj = BOMIACG(gamma_d, sigma_max, k_2, R_f, phi)
+            obj.gamma_d = gamma_d;
+            obj.k_1 = sigma_max - 0.01;
+            obj.k_2 = k_2;
+            obj.R_f = R_f;
+            obj.phi = phi;
+        end
+        
+        % implement
+        function a_M = forward(obj, v_M, sigma_M, lam)
+            e_1 = lam - obj.gamma_d;
+            e_2 = sigma_M;
+            s = e_2 - obj.k_1*obj.sigmoid(e_1);
+            
+            f_2 = (1 + obj.k_1*obj.sigmoidDerivative(e_1))*...
+                abs(sin(sigma_M));
+            a_M = -(v_M/obj.R_f*f_2 + obj.k_2)*v_M*tanh(obj.a*s);
+        end
+        
+        function out = sigmoid(obj, x)
+            out = x/sqrt(x^2 + obj.phi^2);
+        end
+        
+        function out = sigmoidDerivative(obj, x)
+            out = obj.phi^2/((x^2 + obj.phi^2)^(1.5));
+        end
+    end
+end

--- a/missile/guidance/Bearings-Only-Measurement-IACG.md
+++ b/missile/guidance/Bearings-Only-Measurement-IACG.md
@@ -1,0 +1,58 @@
+## Bearings-Only Measurement IACG
+
+##### 2021/09/10
+
+Reference: H. G. Kim, J. Y. Lee, and H. J. Kim, "Look Angle Constrained Impact Angle Control Guidance Law for Homing Missiles With Bearings-Only Measurements", *IEEE Transactions on Aerospace and Electronic Systems* 54.6 (2018): 3096-3107.
+
+
+
+#### Equations of motion
+
+The planar engagement against a stationary target is considered.
+$$
+\begin{align}
+\dot{R} &= -V_{M}\cos\sigma_{M} \\
+\dot{\lambda} &= - \frac{V_{M}}{R}\sin\sigma_{M} \\
+\dot{\gamma}_{M} &= \frac{a_{M}}{V_M}
+\end{align}
+$$
+where $R$ is the relative range, $V_{M}$ is the speed of the missile, $\sigma_{M}$ is the seeker's look angle, $\lambda$ is the LOS angle and $\gamma_{M}$​ is the flight path angle of the missile.
+
+
+
+#### Guidance law
+
+Define $e_{1}$ and $e_{2}$ as
+$$
+\begin{align}
+e_{1} &= \lambda - \gamma_{d} \\
+e_{2} &= \sigma_{M}
+\end{align}
+$$
+The sliding surface $S(\sigma_{M}, \lambda)$ is defined as
+$$
+S(\sigma_{M}, \lambda)=e_{2} - k_{1}\textrm{sgmf}(e_{1})
+$$
+where the sigmoid function $\textrm{sgmf}(\cdot)$ is defined as
+$$
+\textrm{sgmf}(x) = \frac{x}{\sqrt{x^2 + \phi^2}}
+$$
+Design parameters $k_{1}$ and $\phi$​ are chosen as
+$$
+0 < k_{1} < \sigma_{M}^{\max} < \frac{\pi}{2},\quad \phi > 0
+$$
+The sliding mode guidance law is defined as
+$$
+a_{M}=-\left( \frac{V_{M}}{R_{f}}f_{2}(\sigma_{M}, \lambda) + k_{2} \right)V_{M}\textrm{tanh}(aS)
+$$
+where
+$$
+\begin{align}
+f_{2}(\sigma_{M}, \lambda) &= \left( 1 + k_{1}\frac{\partial}{\partial e_{1}}\textrm{sgmf}(e_{1}) \right)\vert \sin\sigma_{M} \vert \\
+&= \left( 1 + k_{1}\frac{\phi^{2}}{(e_{1}^{2} + \phi^{2})^{3/2}} \right)\vert \sin\sigma_{M} \vert
+
+\end{align}
+$$
+and $\textrm{tanh}(\cdot)$ is used instead of $\textrm{sgn}(\cdot)$​​ to avoid the chattering caused by the discontinuity.
+
+ 


### PR DESCRIPTION
The following files have been added.
* `BOMIACG` for the guidance law.
* `BOMIACGEngagement` for the simulation model.
* `bomiacg_2dim_engagement_simulation.m` for the test.