### PR TITLE
[Quadrotor] Add a feedback linearization velocity controller (#121)

### DIFF
--- a/multicopter/FBLVelTracking.m
+++ b/multicopter/FBLVelTracking.m
@@ -1,0 +1,57 @@
+classdef FBLVelTracking < MultipleSystem
+    properties
+        quadrotor
+        velControl
+    end
+    methods
+        function obj = FBLVelTracking()
+            obj = obj@MultipleSystem();
+            
+            % quadrotor model
+            m = 0.5;
+            J = diag([4.85, 4.85, 8.81]*1e-3);
+            
+            pos = [0; 0; 0];
+            vel = [0; 0; 0];
+            R_iv = eye(3);
+            omega = [0; 0; 0];
+            initialState = {pos, vel, R_iv, omega};
+            
+            obj.quadrotor = QuadrotorDyn(initialState, m, J);
+            
+            % velocity controller
+            obj.velControl = DiscreteFunction(...
+                FBLVelControl(m, J), 1/100); % 100 Hz
+            
+            obj.attachDynSystems({obj.quadrotor});
+            obj.attachDiscSystems({obj.velControl});
+        end
+        
+        % implement
+        function forward(obj, v_d)
+            quadState = obj.quadrotor.stateValueList;
+            v = quadState{2};
+            R = quadState{3};
+            omega = quadState{4};
+            
+            eta = Orientations.rotationToEulerAngles(R.');
+            u = obj.velControl.forward(v, eta, omega, v_d);
+            
+            obj.quadrotor.forward(u);
+        end
+    end
+    methods(Static)
+        function test()
+            clc
+            close all
+            
+            fprintf("== Test for FBLVelTracking == \n")
+            
+            v_d = [0.5; 0; 1];
+            model = FBLVelTracking();
+            Simulator(model).propagate(0.01, 10, true, v_d);
+            
+            model.quadrotor.plot();
+        end
+    end
+end

--- a/multicopter/control/FBLVelControl.m
+++ b/multicopter/control/FBLVelControl.m
@@ -1,0 +1,76 @@
+classdef FBLVelControl < BaseFunction
+    % Reference: H. Voos, "Nonlinear Control of a Quadrotor Micro-UAV using
+    % Feedback-Linearization", Proceedings of the 2009 IEEE International
+    % Conference on Mechatronics, 2009.
+    properties
+        m
+        J
+        k_p_att = [1600; 1600; 1600]
+        k_d_att = [80; 80; 80]
+        k_p_vel = [5; 5; 5]
+    end
+    methods
+        function obj = FBLVelControl(m, J, k_p_att, k_d_att, k_p_vel)
+            obj.m = m;
+            obj.J = J;
+            if nargin > 3
+                obj.k_p_att = k_p_att;
+                obj.k_d_att = k_d_att;
+                obj.k_p_vel = k_p_vel;
+            end
+        end
+        
+        % implement
+        function u = forward(obj, v, eta, omega, v_d)
+            % v: velocity
+            % eta: euler angles [phi; theta; psi]
+            % omega: angular velocity
+            % v_d: desired velocity\
+            if nargin < 5
+                v_d = zeros(3, 1);
+            end
+            u_tilde = obj.k_p_vel.*(v_d - v);
+            
+            u_t_1 = u_tilde(1);
+            u_t_2 = u_tilde(2);
+            u_t_3 = u_tilde(3);
+            g = FlatEarthEnv.gravAccel;
+            
+            if abs(u_t_1) > 1e-4
+                beta = -sign(u_t_1)/sqrt(...
+                    1 + ((g - u_t_3)/u_t_1)^2);
+                f = obj.m*sqrt(...
+                    (u_t_1/beta)^2 + u_t_2^2);
+                alpha = obj.m/f*u_t_2;
+            else
+                beta = 0;
+                f = obj.m*sqrt(...
+                    u_t_2^2 + (g - u_t_3)^2);
+                alpha = obj.m/f*u_t_2;
+            end
+            phi_d = real(asin(alpha));
+            theta_d = real(asin(beta));
+            psi_d = 0;
+            
+            eta_d = [phi_d; theta_d; psi_d];
+            u_star = obj.k_p_att.*(eta_d - eta) - obj.k_d_att.*omega;
+            
+            J_x = obj.J(1, 1);
+            J_y = obj.J(2, 2);
+            J_z = obj.J(3, 3);
+            J_1 = (J_y - J_z)/J_x;
+            J_2 = (J_z - J_x)/J_y;
+            J_3 = (J_x - J_y)/J_z;
+            
+            p = omega(1);
+            q = omega(2);
+            r = omega(3);
+            tau_x = J_x*(-q*r*J_1 + u_star(1));
+            tau_y = J_y*(-p*r*J_2 + u_star(2));
+            tau_z = J_z*(-p*q*J_3 + u_star(3));
+            
+            u = [f; tau_x; tau_y; tau_z];
+        end
+    end
+end
+                

--- a/multicopter/control/Feedback-Linearization-Velocity-Control.md
+++ b/multicopter/control/Feedback-Linearization-Velocity-Control.md
@@ -1,0 +1,145 @@
+## Feedback Linearization Velocity Control
+
+##### 2021/09/15
+
+Contents of this document is based on the following reference:
+
+H. Voos, "Nonlinear Control of a Quadrotor Micro-UAV using Feedback-Linearization", Proceedings of the 2009 IEEE International Conference on Mechatronics, 2009.
+
+
+
+#### Simplified dynamic model
+
+Equations of the motion for designing the controller are simplified as
+$$
+\begin{align}
+\ddot{x} &= -(\cos\phi \sin\theta \cos\psi + \sin\phi \sin\psi)\frac{f}{m} \\
+\ddot{y} &= -(\cos\phi \sin\theta \sin\psi - \sin\theta \cos\psi)\frac{f}{m} \\
+\ddot{z} &= g - (\cos\phi \cos\theta)\frac{f}{m} \\
+\ddot{\phi} &= \dot{\theta}\dot{\psi} \left( \frac{I_{y} - I_{z}}{I_{x}} \right) + \frac{\tau_{x}}{I_{x}} \\
+\ddot{\theta} &= \dot{\phi}\dot{\psi} \left( \frac{I_{z} - I_{x}}{I_{y}} \right) + \frac{\tau_{y}}{I_{y}} \\
+\ddot{\psi} &= \dot{\phi}\dot{\theta} \left( \frac{I_{x} - I_{y}}{I_{x}} \right) + \frac{\tau_{z}}{I_{z}}
+\end{align}
+$$
+where $f$​ is the total thrust, $\tau_{x}, \tau_{y}, \tau_{z}$​​ are torques.
+
+Define $x^{T}=(\dot{x}, \dot{y}, \dot{z}, \phi, \theta, \psi, \dot{\phi}, \dot{\theta}, \dot{\psi})$. Then,
+$$
+\dot{x} = 
+\begin{bmatrix}
+-(\cos x_{4} \sin x_{5} \cos x_{6} + \sin x_{4} \sin x_{6})\frac{f}{m} \\
+-(\cos x_{4} \sin x_{5} \sin x_{6} - \sin x_{4} \cos x_{6})\frac{f}{m} \\
+g - (\cos x_{4} \cos x_{5})\frac{f}{m} \\
+x_{7} \\
+x_{8} \\
+x_{9} \\
+x_{8}x_{9}I_{1} + \frac{\tau_{x}}{I_{x}} \\
+x_{7}x_{9}I_{2} + \frac{\tau_{y}}{I_{y}} \\
+x_{7}x_{8}I_{3} + \frac{\tau_{z}}{I_{z}}
+\end{bmatrix}
+$$
+where $I_{1}=(I_{y} - I_{z})/I_{x}$, $I_{2}=(I_{z} - I_{x})/I_{y}$, $I_{3}=(I_{x} - I_{y})/I_{z}$.
+
+
+
+#### Attitude control
+
+Apply a feedback linearization
+$$
+\begin{align}
+\tau_{x} &= I_{x}(-x_{8}x_{9}I_{1} + u_{2}^{\ast}) \\
+\tau_{y} &= I_{y}(-x_{7}x_{9}I_{2} + u_{3}^{\ast}) \\
+\tau_{z} &= I_{z}(-x_{7}x_{8}I_{3} + u_{4}^{\ast})
+\end{align}
+$$
+Then we get
+$$
+\begin{align}
+\dot{x}_{7} &= u_{2}^{\ast} \\
+\dot{x}_{8} &= u_{3}^{\ast} \\
+\dot{x}_{9} &= u_{4}^{\ast}
+\end{align}
+$$
+Note that
+$$
+\dot{x}_{4} = x_{7};\quad\ddot{x}_{4}=u_{2}^{\ast}
+$$
+Application of PD control $u_{2}^{\ast} = k_{p, 2}(x_{4d} - x_{4}) - k_{d, 2}\dot{x}_{4}$​ leads to
+$$
+\ddot{x}_{4} + k_{d, 2}\dot{x}_{4} + k_{p, 2}x_{4} = k_{p, 2}x_{4d};\quad \frac{X_{4}(s)}{X_{4d}(s)} = \frac{k_{p, 2}}{s^{2} + k_{d,2}s + k_{p, 2}}
+$$
+A choice of $k_{d, 2}=80$ leads to a settling time of approximately $T_{s} \approx 0.1$ sec and a choice of $k_{p, 2}=(k_{d,2}/2)^{2}$​ leads to zero overshoot.
+
+The same consideration hold for the other two angles.
+
+
+
+#### Velocity control
+
+The velocity dynamic can be expressed as
+$$
+\begin{align}
+\dot{x}_{1} &= -(\cos x_{4d} \sin x_{5d} \cos x_{6d} + \sin x_{4d} \sin x_{6d})\frac{f}{m} = \tilde{u}_{1} \\
+\dot{x}_{2} &= -(\cos x_{4d} \sin x_{5d} \sin x_{6d} - \sin x_{4d} \cos x_{6d})\frac{f}{m} = \tilde{u}_{2} \\
+\dot{x}_{3} &= g - (\cos x_{4d} \cos x_{5d})\frac{f}{m} = \tilde{u}_{3}
+\end{align}
+$$
+where $x_{4d}, x_{5d}, x_{6d}$​ are the desired attitude angles. Pure proportional control can be used for the system as
+$$
+\begin{align}
+\tilde{u}_{1} &= k_{1}(x_{1d} - x_{1}) \\
+\tilde{u}_{2} &= k_{2}(x_{2d} - x_{2}) \\
+\tilde{u}_{3} &= k_{3}(x_{3d} - x_{3})
+\end{align}
+$$
+It is obvious that any desired velocity vector can be achieved without any yaw rotation and $x_{6d}$​ can be set as zero.
+$$
+\begin{align}
+\tilde{u}_{1} &= -\cos x_{4d}\sin x_{5d} \frac{f}{m} \\
+\tilde{u}_{2} &= \sin x_{4d} \frac{f}{m} \\
+\tilde{u}_{3} &= g - \cos x_{4d}\cos x_{5d} \frac{f}{m}
+\end{align}
+$$
+Define the following substitution:
+$$
+\begin{align}
+\alpha &= \sin x_{4d} \quad \Rightarrow \quad \cos x_{4d} = \sqrt{1 - \alpha^{2}} \quad \left( -\frac{\pi}{2} < x_{4d} < \frac{\pi}{2} \right) \\
+\beta &= \sin x_{5d} \quad \Rightarrow \quad \cos x_{5d} = \sqrt{1 - \beta^{2}} \quad \left( -\frac{\pi}{2} < x_{5d} < \frac{\pi}{2} \right)
+\end{align}
+$$
+For $\tilde{u}_{1} > 0$​, we obtain the following solution
+$$
+\begin{align}
+\beta &= -\left(
+1 + \left( \frac{g - \tilde{u}_{3}}{\tilde{u}_{1}} \right)^{2} \right)^{-1/2} \\
+f &= m \sqrt{\left( \frac{\tilde{u}_{1}}{\beta} \right)^{2} + \tilde{u}_{2}^{2}} \\
+\alpha &= \frac{m}{f}\tilde{u}_{2}
+\end{align}
+$$
+For $\tilde{u}_{1} < 0$, we obtain the following solution
+$$
+\begin{align}
+\beta &= \left(
+1 + \left( \frac{g - \tilde{u}_{3}}{\tilde{u}_{1}} \right)^{2} \right)^{-1/2} \\
+f &= m \sqrt{\left( \frac{\tilde{u}_{1}}{\beta} \right)^{2} + \tilde{u}_{2}^{2}} \\
+\alpha &= \frac{m}{f}\tilde{u}_{2}
+\end{align}
+$$
+For $\tilde{u}_{1}=0$, we obtain the following solution
+$$
+\begin{align}
+\beta &= 0 \\
+f &= m\sqrt{\tilde{u}_{2}^{2} + (g - \tilde{u}_{3})^{2}} \\
+\alpha &= \frac{m}{f}\tilde{u}_{2}
+\end{align}
+$$
+Finally,
+$$
+x_{4d} = \arcsin \alpha,\quad x_{5d} = \arcsin \beta
+$$
+
+
+ 
+
+
+


### PR DESCRIPTION
* `FBLVelControl` class has been added for velocity control of quadrotor using feedback linearization.
* `FBLVelTracking` class has been added as a simulation model.

Refer to the document for the details.